### PR TITLE
feat(web): 实现完整的用户交互与游戏流程

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@types/dompurify": "^3.0.5",
+        "dompurify": "^3.2.6",
         "pinia": "^3.0.3",
         "vue": "^3.5.13"
       },
@@ -777,6 +779,15 @@
         "win32"
       ]
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.8.tgz",
@@ -793,6 +804,12 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -1085,6 +1102,15 @@
       "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/dompurify": "^3.0.5",
+    "dompurify": "^3.2.6",
     "pinia": "^3.0.3",
     "vue": "^3.5.13"
   },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="gameStore.isLoading" class="loading-overlay">
+  <div v-if="gameStore.isInitializing" class="loading-overlay">
     <p>正在初始化会话...</p>
   </div>
   <div v-else-if="gameStore.error" class="error-overlay">

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -13,12 +13,12 @@
         type="text" 
         v-model="userInput"
         @keyup.enter="sendMessage"
-        :disabled="gameStore.isReplying || gameStore.isWorldCreated"
+        :disabled="gameStore.isReplying || gameStore.gamePhase === 'GAME_OVER'"
         placeholder="输入你的想法..." 
       />
       <button 
         @click="sendMessage"
-        :disabled="gameStore.isReplying || gameStore.isWorldCreated">
+        :disabled="gameStore.isReplying || gameStore.gamePhase === 'GAME_OVER'">
         发送
       </button>
     </div>
@@ -38,6 +38,8 @@ const sendMessage = () => {
   if (userInput.value.trim() && !gameStore.isReplying) {
     if (gameStore.gamePhase === 'WORLD_CREATION') {
         gameStore.sendAgentMessage(userInput.value, 'world-builder');
+    } else if (gameStore.gamePhase === 'CHARACTER_CREATION') {
+        gameStore.sendAgentMessage(userInput.value, 'character-manager');
     }
     // TODO: Add other game phases
     userInput.value = '';

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -40,8 +40,9 @@ const sendMessage = () => {
         gameStore.sendAgentMessage(userInput.value, 'world-builder');
     } else if (gameStore.gamePhase === 'CHARACTER_CREATION') {
         gameStore.sendAgentMessage(userInput.value, 'character-manager');
+    } else if (gameStore.gamePhase === 'GAMEPLAY') {
+        gameStore.sendPlayerInput(userInput.value);
     }
-    // TODO: Add other game phases
     userInput.value = '';
   }
 };

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -4,7 +4,7 @@
       <div v-for="message in gameStore.messages" :key="message.id" class="message" :class="message.sender === 'Player' ? 'player' : 'dm'">
         <p v-html="formatMessage(message.text)"></p>
       </div>
-      <div v-if="gameStore.isLoading" class="message dm">
+      <div v-if="gameStore.isReplying" class="message dm">
         <p><i>DM 正在思考中...</i></p>
       </div>
     </div>
@@ -13,12 +13,12 @@
         type="text" 
         v-model="userInput"
         @keyup.enter="sendMessage"
-        :disabled="gameStore.isLoading || gameStore.isWorldCreated"
+        :disabled="gameStore.isReplying || gameStore.isWorldCreated"
         placeholder="输入你的想法..." 
       />
       <button 
         @click="sendMessage"
-        :disabled="gameStore.isLoading || gameStore.isWorldCreated">
+        :disabled="gameStore.isReplying || gameStore.isWorldCreated">
         发送
       </button>
     </div>
@@ -35,7 +35,7 @@ const userInput = ref('');
 const messagesContainer = ref<HTMLElement | null>(null);
 
 const sendMessage = () => {
-  if (userInput.value.trim() && !gameStore.isLoading) {
+  if (userInput.value.trim() && !gameStore.isReplying) {
     if (gameStore.gamePhase === 'WORLD_CREATION') {
         gameStore.sendAgentMessage(userInput.value, 'world-builder');
     }

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -1,75 +1,145 @@
 <template>
   <div class="chat-window">
-    <div class="messages">
-      <div class="message dm">
-        <p>DM: 你好，冒险者！欢迎来到AI Dungeon Master的世界。请先在左侧进行设置，然后在右侧创建你的世界和角色。</p>
+    <div class="messages" ref="messagesContainer">
+      <div v-for="message in gameStore.messages" :key="message.id" class="message" :class="message.sender === 'Player' ? 'player' : 'dm'">
+        <p v-html="formatMessage(message.text)"></p>
       </div>
-      <div class="message player">
-        <p>You: 我准备好了！</p>
+      <div v-if="gameStore.isLoading" class="message dm">
+        <p><i>DM 正在思考中...</i></p>
       </div>
     </div>
     <div class="input-area">
-      <input type="text" placeholder="输入你的行动..." />
-      <button>发送</button>
+      <input 
+        type="text" 
+        v-model="userInput"
+        @keyup.enter="sendMessage"
+        :disabled="gameStore.isLoading || gameStore.isWorldCreated"
+        placeholder="输入你的想法..." 
+      />
+      <button 
+        @click="sendMessage"
+        :disabled="gameStore.isLoading || gameStore.isWorldCreated">
+        发送
+      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// 未来这里将包含处理消息发送和接收的逻辑
+import { ref, watch, nextTick } from 'vue';
+import { useGameStore } from '@/stores/gameStore';
+import DOMPurify from 'dompurify';
+
+const gameStore = useGameStore();
+const userInput = ref('');
+const messagesContainer = ref<HTMLElement | null>(null);
+
+const sendMessage = () => {
+  if (userInput.value.trim() && !gameStore.isLoading) {
+    if (gameStore.gamePhase === 'WORLD_CREATION') {
+        gameStore.sendAgentMessage(userInput.value, 'world-builder');
+    }
+    // TODO: Add other game phases
+    userInput.value = '';
+  }
+};
+
+const formatMessage = (text: string) => {
+    const sanitized = DOMPurify.sanitize(text.replace(/\n/g, '<br>'));
+    return sanitized;
+}
+
+const scrollToBottom = () => {
+    nextTick(() => {
+        if (messagesContainer.value) {
+            messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight;
+        }
+    });
+};
+
+watch(() => gameStore.messages, scrollToBottom, { deep: true });
 </script>
 
 <style scoped>
 .chat-window {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 100vh; /* 改为视口高度 */
+  max-height: 100vh;
 }
 
 .messages {
   flex-grow: 1;
   padding: 1rem;
   overflow-y: auto;
+  background-color: #fff;
 }
 
 .message {
   margin-bottom: 1rem;
+  display: flex;
 }
 
 .message p {
   margin: 0;
-  padding: 0.5rem 1rem;
-  border-radius: 10px;
-  max-width: 80%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  max-width: 85%;
+  line-height: 1.5;
+  word-wrap: break-word;
 }
 
+.message.dm {
+    justify-content: flex-start;
+}
 .message.dm p {
   background-color: #f1f1f1;
-  text-align: left;
+  color: #333;
+  border-bottom-left-radius: 2px;
 }
 
+.message.player {
+    justify-content: flex-end;
+}
 .message.player p {
-  background-color: #d1e7ff;
-  margin-left: auto;
-  text-align: right;
+  background-color: #007bff;
+  color: white;
+  border-bottom-right-radius: 2px;
 }
-
 
 .input-area {
   display: flex;
   padding: 1rem;
   border-top: 1px solid var(--border-color);
+  background-color: #fcfcfc;
 }
 
 .input-area input {
   flex-grow: 1;
   border: 1px solid #ccc;
-  border-radius: 5px;
-  padding: 0.5rem;
+  border-radius: 20px;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+.input-area input:disabled {
+    background-color: #eee;
 }
 
 .input-area button {
   margin-left: 1rem;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1.5rem;
+  border: none;
+  background-color: #007bff;
+  color: white;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.input-area button:hover {
+    background-color: #0056b3;
+}
+.input-area button:disabled {
+    background-color: #a0a0a0;
+    cursor: not-allowed;
 }
 </style> 

--- a/frontend/src/components/RightPanel.vue
+++ b/frontend/src/components/RightPanel.vue
@@ -16,7 +16,7 @@
       <h3>角色状态</h3>
       <div v-if="Object.keys(gameStore.characterState).length > 0">
          <p v-for="(value, key) in gameStore.characterState" :key="key">
-            <span class="state-key">{{ key }}:</span>
+            <span class="state-key">{{ characterStateMap[key] || key }}:</span>
             <span class="state-value">{{ value || '...' }}</span>
         </p>
       </div>
@@ -36,6 +36,15 @@ const worldStateMap: Record<string, string> = {
     history: "历史背景",
     cultures: "文化设定",
     magic_system: "魔法体系",
+    additional_info: "额外信息"
+};
+
+const characterStateMap: Record<string, string> = {
+    name: "角色名称",
+    physical_appearance: "外貌描述",
+    background: "背景故事",
+    internal_motivation: "内在动机",
+    unique_traits: "独特特征",
     additional_info: "额外信息"
 };
 

--- a/frontend/src/components/RightPanel.vue
+++ b/frontend/src/components/RightPanel.vue
@@ -3,32 +3,76 @@
     <h2>状态</h2>
     <div class="state-section">
       <h3>世界状态</h3>
-      <p>名称: 尚未创建</p>
-      <p>地理: ...</p>
+      <div v-if="Object.keys(gameStore.worldState).length > 0">
+        <p v-for="(value, key) in gameStore.worldState" :key="key">
+            <span class="state-key">{{ worldStateMap[key] || key }}:</span>
+            <span class="state-value">{{ value || '...' }}</span>
+        </p>
+      </div>
+      <p v-else>世界尚未被创造...</p>
     </div>
+    <hr/>
     <div class="state-section">
       <h3>角色状态</h3>
-      <p>姓名: 尚未创建</p>
-      <p>背景: ...</p>
+      <div v-if="Object.keys(gameStore.characterState).length > 0">
+         <p v-for="(value, key) in gameStore.characterState" :key="key">
+            <span class="state-key">{{ key }}:</span>
+            <span class="state-value">{{ value || '...' }}</span>
+        </p>
+      </div>
+      <p v-else>角色尚未被创造...</p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// 未来这里将包含从API获取并显示状态的逻辑
+import { useGameStore } from '@/stores/gameStore';
+
+const gameStore = useGameStore();
+
+const worldStateMap: Record<string, string> = {
+    name: "世界名称",
+    geography: "地理环境",
+    history: "历史背景",
+    cultures: "文化设定",
+    magic_system: "魔法体系",
+    additional_info: "额外信息"
+};
+
 </script>
 
 <style scoped>
 .right-panel {
   padding: 1rem;
   border-left: 1px solid var(--border-color);
+  background-color: #fcfcfc;
 }
 
 h2, h3 {
   margin-top: 0;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .state-section {
   margin-bottom: 1.5rem;
+}
+.state-section p {
+    margin: 0.5rem 0;
+    line-height: 1.6;
+}
+.state-key {
+    font-weight: bold;
+    margin-right: 0.5rem;
+    color: #333;
+}
+.state-value {
+    color: #555;
+}
+hr {
+    border: none;
+    border-top: 1px solid var(--border-color);
+    margin: 1.5rem 0;
 }
 </style> 

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -5,32 +5,45 @@ const API_BASE_URL = 'http://localhost:8000';
 // --- 数据模型定义 (根据 API.md) ---
 
 export interface WorldState {
-  name: string;
-  geography: string;
-  history: string;
-  cultures: string;
-  magic_system: string;
-  additional_info: Record<string, any>;
+    name: string;
+    geography: string;
+    history: string;
+    cultures: string;
+    magic_system: string;
+    additional_info: Record<string, any>;
 }
 
 export interface CharacterState {
-  name: string;
-  physical_appearance: string;
-  background: string;
-  internal_motivation: string;
-  unique_traits: string;
-  additional_info: Record<string, any>;
+    name: string;
+    physical_appearance: string;
+    background: string;
+    internal_motivation: string;
+    unique_traits: string;
+    additional_info: Record<string, any>;
 }
 
 export interface NarrativeResponse {
-  inner_monologue: string;
-  narrative: string;
-  is_game_over: boolean;
+    inner_monologue: string;
+    narrative: string;
+    is_game_over: boolean;
 }
 
 export interface SessionResponse {
-  session_id: string;
-  message: string;
+    session_id: string;
+    message: string;
+}
+
+export interface FormDefinitionResponse {
+    fields: string[];
+    field_map: Record<string, string>;
+}
+
+export type AgentType = 'world-builder' | 'character-manager';
+
+export interface AgentProcessResponse {
+    response: string;
+    is_complete: boolean;
+    updated_state: Partial<WorldState> | Partial<CharacterState>;
 }
 
 // --- API 调用封装 ---
@@ -41,18 +54,58 @@ export interface SessionResponse {
  * @returns {Promise<SessionResponse>}
  */
 export async function createSession(sessionId?: string): Promise<SessionResponse> {
-  const response = await fetch(`${API_BASE_URL}/api/sessions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ session_id: sessionId }),
-  });
+    const response = await fetch(`${API_BASE_URL}/api/sessions`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ session_id: sessionId }),
+    });
 
-  if (!response.ok) {
-    const errorData = await response.json();
-    throw new Error(errorData.detail || '创建会话失败');
-  }
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || '创建会话失败');
+    }
 
-  return response.json();
+    return response.json();
+}
+
+/**
+ * 获取指定表单Agent的动态表单定义
+ * @param agentType - Agent类型
+ * @returns {Promise<FormDefinitionResponse>}
+ */
+export async function getForm(agentType: AgentType): Promise<FormDefinitionResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/agents/${agentType}/form`);
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || `获取 ${agentType} 表单失败`);
+    }
+
+    return response.json();
+}
+
+/**
+ * 使用指定的表单Agent处理用户输入
+ * @param agentType - Agent类型
+ * @param sessionId - 当前会话ID
+ * @param userInput - 用户输入
+ * @returns {Promise<AgentProcessResponse>}
+ */
+export async function processAgentInput(agentType: AgentType, sessionId: string, userInput: string): Promise<AgentProcessResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/agents/${agentType}/process`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ session_id: sessionId, user_input: userInput }),
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || `处理 ${agentType} 输入失败`);
+    }
+
+    return response.json();
 } 

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -46,6 +46,15 @@ export interface AgentProcessResponse {
     updated_state: Partial<WorldState> | Partial<CharacterState>;
 }
 
+export interface SessionStatusResponse {
+    session_id: string;
+    world_complete: boolean;
+    character_complete: boolean;
+    ready_for_game: boolean;
+    world_state: WorldState;
+    character_state: CharacterState;
+}
+
 // --- API 调用封装 ---
 
 /**
@@ -65,6 +74,22 @@ export async function createSession(sessionId?: string): Promise<SessionResponse
     if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.detail || '创建会话失败');
+    }
+
+    return response.json();
+}
+
+/**
+ * 获取会话状态和信息
+ * @param sessionId - 会话唯一标识符
+ * @returns {Promise<SessionStatusResponse>}
+ */
+export async function getSessionStatus(sessionId: string): Promise<SessionStatusResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/sessions/${sessionId}`);
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || '获取会话状态失败');
     }
 
     return response.json();
@@ -105,6 +130,29 @@ export async function processAgentInput(agentType: AgentType, sessionId: string,
     if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.detail || `处理 ${agentType} 输入失败`);
+    }
+
+    return response.json();
+}
+
+/**
+ * 进行一轮游戏
+ * @param sessionId - 当前会话ID
+ * @param userInput - 玩家输入
+ * @returns {Promise<NarrativeResponse>}
+ */
+export async function playGame(sessionId: string, userInput: string): Promise<NarrativeResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/game/play`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ session_id: sessionId, user_input: userInput }),
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || '游戏主循环失败');
     }
 
     return response.json();

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -90,17 +90,37 @@ export const useGameStore = defineStore('game', {
                     this.worldState = result.updated_state as WorldState;
                     if (result.is_complete) {
                         this.isWorldCreated = true;
-                        this.gamePhase = 'CHARACTER_CREATION';
-                        // TODO: 触发角色创建流程
                         this.addMessage("世界已经创建完毕！接下来，让我们创建你的角色吧。", 'DM');
+                        this.startCharacterCreation();
+                    }
+                } else if (agentType === 'character-manager') {
+                    this.characterState = result.updated_state as CharacterState;
+                    if (result.is_complete) {
+                        this.isCharacterCreated = true;
+                        this.gamePhase = 'GAMEPLAY';
+                        this.addMessage("角色创建完成！你的冒险现在正式开始。", "DM");
+                        // TODO: 触发游戏主循环
                     }
                 }
-                // TODO: 添加 character-manager 的逻辑
             } catch (error: any) {
                 this.error = error.message || 'Failed to process input';
             } finally {
                 this.isReplying = false;
             }
-        }
+        },
+
+        async startCharacterCreation() {
+            if (!this.sessionId) return;
+            this.gamePhase = 'CHARACTER_CREATION';
+            this.isReplying = true;
+            try {
+                const firstPrompt = await processAgentInput('character-manager', this.sessionId, "你好，我想创建一个角色。");
+                this.addMessage(firstPrompt.response, 'DM');
+            } catch (error: any) {
+                this.error = error.message || 'Failed to start character creation';
+            } finally {
+                this.isReplying = false;
+            }
+        },
     },
 }); 

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { createSession, getForm, processAgentInput, type AgentType } from '@/services/apiService';
+import { createSession, getForm, processAgentInput, type AgentType, playGame, getSessionStatus } from '@/services/apiService';
 import type { WorldState, CharacterState } from '@/services/apiService';
 
 export type GamePhase = 'INIT' | 'WORLD_CREATION' | 'CHARACTER_CREATION' | 'GAMEPLAY' | 'GAME_OVER';
@@ -97,13 +97,35 @@ export const useGameStore = defineStore('game', {
                     this.characterState = result.updated_state as CharacterState;
                     if (result.is_complete) {
                         this.isCharacterCreated = true;
-                        this.gamePhase = 'GAMEPLAY';
-                        this.addMessage("角色创建完成！你的冒险现在正式开始。", "DM");
-                        // TODO: 触发游戏主循环
+                        this.addMessage("角色创建完成！正在准备你的冒险...", "DM");
+                        this.pollForGameReady();
                     }
                 }
             } catch (error: any) {
                 this.error = error.message || 'Failed to process input';
+            } finally {
+                this.isReplying = false;
+            }
+        },
+
+        async sendPlayerInput(userInput: string) {
+            if (!this.sessionId) return;
+
+            // 在游戏开场时，玩家的输入（"开始"）不应显示
+            if (userInput !== "开始") {
+                this.addMessage(userInput, 'Player');
+            }
+
+            this.isReplying = true;
+            try {
+                const result = await playGame(this.sessionId, userInput);
+                this.addMessage(result.narrative, 'DM');
+                if (result.is_game_over) {
+                    this.gamePhase = 'GAME_OVER';
+                    this.addMessage("游戏结束。感谢你的游玩！", "DM");
+                }
+            } catch (error: any) {
+                this.error = error.message || 'Failed to process player input';
             } finally {
                 this.isReplying = false;
             }
@@ -121,6 +143,39 @@ export const useGameStore = defineStore('game', {
             } finally {
                 this.isReplying = false;
             }
+        },
+
+        pollForGameReady() {
+            if (!this.sessionId) return;
+
+            const intervalId = setInterval(async () => {
+                if (!this.sessionId) {
+                    clearInterval(intervalId);
+                    return;
+                }
+                try {
+                    const status = await getSessionStatus(this.sessionId);
+                    if (status.ready_for_game) {
+                        clearInterval(intervalId);
+                        this.gamePhase = 'GAMEPLAY';
+                        this.addMessage("你的冒险现在正式开始。", "DM");
+                        this.sendPlayerInput("开始");
+                    }
+                } catch (error) {
+                    this.error = "无法验证游戏状态，请稍后重试。";
+                    clearInterval(intervalId);
+                }
+            }, 1000); // 每秒查询一次
+
+            // 设置一个超时，以防万一
+            setTimeout(() => {
+                if (this.gamePhase !== 'GAMEPLAY') {
+                    clearInterval(intervalId);
+                    if (!this.error) {
+                        this.error = "游戏准备超时，请尝试刷新页面。";
+                    }
+                }
+            }, 20000); // 20秒超时
         },
     },
 }); 


### PR DESCRIPTION
## 概述 (Overview)

该 PR 在前端实现了从会话开始到游戏结束的完整用户交互流程。它建立在 `feat/frontend-scaffolding` 的基础之上，引入了与后端 Agent 的完整通信逻辑，并打通了世界创建、角色创建和主游戏循环三大核心阶段。

此外，该 PR 还修复了在开发过程中发现的多个关键 Bug，显著提升了应用的稳定性和用户体验。

## 主要变更 (Key Changes)

- **世界创建流程 (`WORLD_CREATION`):**
  - 实现了与 `world-builder` Agent 的完整对话式交互。
  - `RightPanel` 现在可以实时展示 `WorldState` 的更新。

- **角色创建流程 (`CHARACTER_CREATION`):**
  - 在世界创建完成后，流程会自动、无缝地过渡到角色创建。
  - 实现了与 `character-manager` Agent 的交互。
  - `RightPanel` 会同步展示 `CharacterState` 的更新。

- **主游戏循环 (`GAMEPLAY`):**
  - 在角色创建完成后，通过轮询机制确认后端就绪，然后自动开始游戏。
  - 实现了与 `/api/game/play` 端点的交互，驱动核心叙事流程。

- **关键 Bug 修复 (Bug Fixes):**
  - **加载状态 (`fix(ui)`):** 将全局加载状态细化为“初始化”和“AI回复中”，避免了在每次交互时都出现全屏加载遮罩，改善了用户体验。
  - **输入框禁用 (`fix(ui)`):** 修复了因状态判断错误导致输入框在不当时机被永久禁用的问题。
  - **竞态条件 (`fix(web)`):** 用一个健壮的、基于 API 契约的轮询机制取代了不可靠的 `setTimeout`，彻底解决了因前后端状态不一致导致的游戏开始失败问题。

## 如何测试 (How to Test)

1.  切换到 `feat/agent-interaction-flow` 分支。
2.  确保前端 (`npm run dev`) 和后端 (`uvicorn ...`) 服务都已启动。
3.  在浏览器中打开前端页面。
4.  完整体验以下流程：
    - 应用自动开始世界创建。
    - 与 DM 对话完成世界创建。
    - 流程自动进入角色创建，与 DM 对话完成角色创建。
    - 流程自动进入主游戏循环，并收到开场白。
    - 输入指令，获得游戏叙事反馈。
5.  确认整个过程流畅，没有出现错误或卡顿。