### PR TITLE
feat(core): 实现完整的SSE流式响应与交互优化

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,9 +41,17 @@ app = FastAPI(
 )
 
 # CORS配置
+# 定义允许的前端源
+origins = [
+    "http://localhost",
+    "http://localhost:5173",  # Vue3 Vite 开发服务器的默认地址
+    "http://127.0.0.1:5173",
+    # 如果您有其他前端部署地址，也一并加入
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,  # 将 "*" 修改为具体的源列表
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/models/game_state.py
+++ b/backend/app/models/game_state.py
@@ -94,6 +94,10 @@ class GameSession(BaseModel):
     character_state: CharacterState = Field(
         default_factory=CharacterState, description="角色状态"
     )
+    # 添加两个状态标志
+    is_world_created: bool = Field(False, description="世界是否已创建完成")
+    is_character_created: bool = Field(False, description="角色是否已创建完成")
+
     current_scene: Optional[str] = Field(default=None, description="当前场景描述")
     game_history: List[Dict[str, str]] = Field(
         default_factory=list, description="游戏历史记录"
@@ -109,32 +113,16 @@ class GameSession(BaseModel):
         self.updated_at = datetime.now()
 
     def is_world_complete(self) -> bool:
-        """检查世界设定是否完整"""
-        return all(
-            [
-                self.world_state.name,
-                self.world_state.geography,
-                self.world_state.history,
-                self.world_state.cultures,
-                self.world_state.magic_system,
-            ]
-        )
+        """检查世界设定是否完整 (此方法将被弃用)"""
+        return self.is_world_created
 
     def is_character_complete(self) -> bool:
-        """检查角色设定是否完整"""
-        return all(
-            [
-                self.character_state.name,
-                self.character_state.physical_appearance,
-                self.character_state.background,
-                self.character_state.personality,
-                self.character_state.abilities,
-            ]
-        )
+        """检查角色设定是否完整 (此方法将被弃用)"""
+        return self.is_character_created
 
     def is_ready_for_game(self) -> bool:
         """检查是否可以开始游戏"""
-        return self.is_world_complete() and self.is_character_complete()
+        return self.is_world_created and self.is_character_created
 
 
 class SessionStore:

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -99,6 +99,15 @@ async def process_with_agent(
             {"session": session, "user_input": request.user_input}
         )
 
+        # 检查Agent是否发出了创建完成的信号 (修正：应该检查字典中的 'is_complete' 键)
+        if result.get("is_complete", False):
+            if agent_type == "world-builder":
+                session.is_world_created = True
+                print(f"世界创建完成 for session {session.session_id}")
+            elif agent_type == "character-manager":
+                session.is_character_created = True
+                print(f"角色创建完成 for session {session.session_id}")
+
         # Agent处理后, GameSession的状态可能已改变, 我们需要更新它
         session_store.update_session(session)
 

--- a/backend/app/routers/game.py
+++ b/backend/app/routers/game.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+import asyncio
+import json
 
 from app.models.game_state import NarrativeResponse, session_store
 from app.routers.agents import AGENT_INSTANCES
@@ -54,3 +57,58 @@ async def play_turn(request: GamePlayRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"处理游戏回合时发生错误: {str(e)}")
+
+
+@router.post("/play/stream")
+async def play_turn_stream(request: GamePlayRequest):
+    """
+    游戏主循环的流式端点。
+    """
+    session = session_store.get_session(request.session_id)
+    if not session:
+        raise HTTPException(
+            status_code=404, detail=f"会话 '{request.session_id}' 不存在"
+        )
+    if not session.is_ready_for_game():
+        raise HTTPException(
+            status_code=400, detail="游戏尚未准备就绪。请先完成世界和角色的创建。"
+        )
+
+    narrative_agent = AGENT_INSTANCES.get("narrative-generator")
+    if not narrative_agent:
+        raise HTTPException(status_code=500, detail="核心叙事Agent未初始化")
+
+    async def stream_generator():
+        try:
+            full_response = NarrativeResponse(
+                narrative="", is_game_over=False, inner_monologue=""
+            )
+            async for chunk in narrative_agent.stream_process(
+                {"session": session, "user_input": request.user_input}
+            ):
+                # 累积完整的响应对象
+                full_response += chunk
+
+                # 仅流式传输 narrative 文本部分
+                if chunk.narrative:
+                    # 对于SSE，每个消息都必须以 "data: " 开头，并以 "\n\n" 结尾
+                    # 我们需要对多行文本进行特殊处理
+                    for line in chunk.narrative.split("\n"):
+                        yield f"data: {json.dumps(line)}\n"
+                    yield "\n"  # 在多行消息块后发送一个空行，表示一个消息的结束
+                    await asyncio.sleep(0.02)  # 轻微延迟以改善前端接收效果
+
+            # 流结束后，检查游戏是否结束
+            if full_response.is_game_over:
+                session_store.delete_session(request.session_id)
+                print(f"游戏会话 {request.session_id} 已结束并被清理。")
+
+        except Exception as e:
+            # 在流中处理错误
+            error_message = json.dumps({"error": f"处理游戏回合时发生错误: {str(e)}"})
+            yield f"data: {error_message}\n\n"
+        finally:
+            # 发送一个特殊的结束信号
+            yield "data: [DONE]\n\n"
+
+    return StreamingResponse(stream_generator(), media_type="text/event-stream")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.2.6",
         "pinia": "^3.0.3",
@@ -497,6 +498,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@types/dompurify": "^3.0.5",
     "dompurify": "^3.2.6",
     "pinia": "^3.0.3",

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -1,9 +1,20 @@
 <template>
   <div class="chat-window">
     <div class="messages" ref="messagesContainer">
-      <div v-for="message in gameStore.messages" :key="message.id" class="message" :class="message.sender === 'Player' ? 'player' : 'dm'">
-        <p v-html="formatMessage(message.text)"></p>
-      </div>
+      <template v-for="message in gameStore.messages" :key="message.id">
+        <!-- System Message -->
+        <div v-if="message.sender === 'System'" class="system-message">
+          <hr class="divider" />
+          <span>{{ message.text }}</span>
+          <hr class="divider" />
+        </div>
+
+        <!-- Player & DM Messages (Original a web p t a g e) -->
+        <div v-else class="message" :class="message.sender === 'Player' ? 'player' : 'dm'">
+          <p v-html="formatMessage(message.text)"></p>
+        </div>
+      </template>
+
       <div v-if="gameStore.isReplying" class="message dm">
         <p><i>DM 正在思考中...</i></p>
       </div>
@@ -144,5 +155,24 @@ watch(() => gameStore.messages, scrollToBottom, { deep: true });
 .input-area button:disabled {
     background-color: #a0a0a0;
     cursor: not-allowed;
+}
+
+/* System Message Styling */
+.system-message {
+  width: 100%;
+  text-align: center;
+  margin: 20px 0;
+  color: #888;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.system-message .divider {
+  flex-grow: 1;
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 0 10px;
 }
 </style> 

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -168,10 +168,13 @@ export async function streamPlayGame(
             body: JSON.stringify({ session_id: sessionId, user_input: userInput }),
 
             async onopen(response) {
-                if (response.ok && response.headers.get('content-type') === 'text/event-stream') {
+                const contentType = response.headers.get('content-type') || '';
+                if (response.ok && contentType.includes('text/event-stream')) {
                     return; // 连接成功
                 }
-                throw new Error(`Failed to connect in event-stream mode, status: ${response.status}`);
+                throw new Error(
+                    `Failed to connect in event-stream mode, status: ${response.status}, content-type: ${contentType}`
+                );
             },
 
             onmessage(event) {

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { createSession, getForm, processAgentInput, type AgentType, playGame, getSessionStatus, streamPlayGame } from '@/services/apiService';
+import { createSession, processAgentInput, type AgentType, getSessionStatus, streamPlayGame } from '@/services/apiService';
 import type { WorldState, CharacterState, Message } from '@/services/apiService';
 
 export type GamePhase = 'INIT' | 'WORLD_CREATION' | 'CHARACTER_CREATION' | 'GAMEPLAY' | 'GAME_OVER';


### PR DESCRIPTION
## 概述

本次更新为应用引入了完整的 Server-Sent Events (SSE) 流式响应机制，旨在通过实现打字机效果，显著提升游戏主循环中的用户交互体验。从后端的数据流生成到前端的实时渲染，再到一系列关键 Bug 的修复和 UX 优化，确保了该功能的稳定性和高质量。

## 主要变更

### 1. 后端流式架构 (`refactor` & `feat`)
- **叙事 Agent 重构**: `NarrativeGeneratorAgent` 被重构以支持纯文本流输出，解决了 LangChain 中结构化输出与流式响应的内在冲突。
- **SSE 端点实现**: 在 `game.py` 中新增 `/api/game/play/stream` 端点，利用 FastAPI 的 `StreamingResponse` 将 Agent 生成的文本块实时推送给前端。

### 2. 前端流式集成 (`feat`)
- **引入 `fetch-event-source`**: 添加了 `@microsoft/fetch-event-source` 依赖，以健壮地处理带 POST 请求的 SSE 连接。
- **状态管理集成**: 重构了 `gameStore` 中的 `sendPlayerInput` action，使其能够接收并处理文本流，动态更新聊天消息，为打字机效果提供了数据基础。

### 3. 关键问题修复 (`fix`)
- **游戏流程阻塞**: 修复了因 `is_ready_for_game` 判断逻辑过于严格，导致前端在创建阶段无限轮询的 Bug。通过在 `GameSession` 中引入更灵活的 `is_world_created` 和 `is_character_created` 状态标志解决了此问题。
- **跨域与连接错误**:
  - 修复了 FastAPI 的 CORS 配置，将 `allow_origins` 从 `"*"` 改为明确的来源列表，解决了与带凭据请求的策略冲突。
  - 增强了前端 `onopen` 回调的 `Content-Type` 检查逻辑，使其能兼容带字符集的响应头，彻底解决了连接失败的问题。

### 4. 用户体验优化 (`feat`)
- **优化阶段提示**: 移除了生硬的 DM 文本提示，改为使用优雅的、带分割线的居中系统消息（如“世界创建完成”）来标记游戏阶段的转换，显著提升了游戏的沉浸感和专业度。

## 如何测试

1. 启动前后端服务。
2. 走完世界创建和角色创建流程（可以直接通过输入让流程结束）。
3. 进入主游戏循环，输入任意内容，观察 DM 的回复是否以打字机效果流式输出。
4. 观察世界和角色创建完成时的阶段转换提示是否为新的分割线样式。
